### PR TITLE
Add functionality to force starting subprocess #34

### DIFF
--- a/src/main/java/no/cantara/jau/JavaAutoUpdater.java
+++ b/src/main/java/no/cantara/jau/JavaAutoUpdater.java
@@ -96,8 +96,15 @@ public class JavaAutoUpdater {
                 boolean successKillingProcess = duplicateProcessHandler.killExistingProcessIfRunning(processCommand);
 
                 if (!successKillingProcess) {
-                    log.error("Problem killing running process! A new managed process will not be started. " +
-                              "Retrying in {} seconds", sleepTime / 1000);
+                    boolean forceStartSubProcess = PropertiesHelper.forceStartSubProcess();
+                    if (forceStartSubProcess) {
+                        log.warn("Problem killing running process. Will start a new managed process as the" +
+                                "flag 'forceStartSubProcess' is set to true. This may lead to duplicate " +
+                                "subprocesses.");
+                    } else {
+                        log.error("Problem killing running process! A new managed process will not be started. " +
+                                "Retrying in {} seconds", sleepTime / 1000);
+                    }
                 } else {
                     processMonitorHandle = startProcessMonitorThread(isRunningInterval);
                 }

--- a/src/main/java/no/cantara/jau/duplicatehandler/DuplicateProcessHandler.java
+++ b/src/main/java/no/cantara/jau/duplicatehandler/DuplicateProcessHandler.java
@@ -30,7 +30,8 @@ public class DuplicateProcessHandler {
         try {
             pid = fileUtil.getRunningProcessPidFromFile();
         } catch (IOException e) {
-            log.warn("Could not read file={}.", fileUtil.getFileName());
+            log.warn("Could not read file={}. Attempting to kill process by searching for processes with " +
+                            "processCommand={}", fileUtil.getFileName(), processCommand);
             return findRunningProcessByProcessNameAndKill(processCommand);
         }
         if (pid != null) {
@@ -84,9 +85,7 @@ public class DuplicateProcessHandler {
     private boolean killRunningProcessByProcessName(String processName) {
         try {
             return processExecutor.killProcessByProcessName(processName);
-        } catch (IOException e) {
-            log.error("Could not kill process by process name", e);
-        } catch (InterruptedException e) {
+        } catch (IOException | InterruptedException e) {
             log.error("Could not kill process by process name", e);
         }
         return false;
@@ -110,8 +109,7 @@ public class DuplicateProcessHandler {
     }
 
     private boolean processIsRunning(String pid) throws IOException, InterruptedException {
-        boolean processRuns = processExecutor.isProcessRunning(pid);
-        return processRuns;
+        return processExecutor.isProcessRunning(pid);
     }
 
     private boolean killRunningProcessByPID(String pid) {

--- a/src/main/java/no/cantara/jau/util/PropertiesHelper.java
+++ b/src/main/java/no/cantara/jau/util/PropertiesHelper.java
@@ -33,10 +33,12 @@ public class PropertiesHelper {
     private static final String IS_RUNNING_INTERVAL_KEY = "isrunninginterval";
     private static final String UPDATE_INTERVAL_KEY = "updateinterval";
     private static final String STOP_APPLICATION_ON_SHUTDOWN_KEY = "stopApplicationOnShutdown";
+    private static final String FORCE_START_SUB_PROCESS = "forceStartSubProcess";
 
     private static final int DEFAULT_UPDATE_INTERVAL = 60; // seconds
     private static final int DEFAULT_IS_RUNNING_INTERVAL = 40; // seconds
     private static final boolean DEFAULT_STOP_APPLICATION_ON_SHUTDOWN = false;
+    private static final boolean DEFAULT_FORCE_START_SUB_PROCESS = false;
 
     public static Properties getPropertiesFromConfigFile(String filename) {
         Properties properties = new Properties();
@@ -157,5 +159,9 @@ public class PropertiesHelper {
 
     public static boolean stopApplicationOnShutdown() {
         return getBooleanProperty(getPropertiesFromConfigFile(JAU_CONFIG_FILENAME), STOP_APPLICATION_ON_SHUTDOWN_KEY, DEFAULT_STOP_APPLICATION_ON_SHUTDOWN);
+    }
+
+    public static boolean forceStartSubProcess() {
+        return getBooleanProperty(getPropertiesFromConfigFile(JAU_CONFIG_FILENAME), FORCE_START_SUB_PROCESS, DEFAULT_FORCE_START_SUB_PROCESS);
     }
 }

--- a/src/main/resources/jau.properties
+++ b/src/main/resources/jau.properties
@@ -11,6 +11,10 @@ clientName=local-jau
 
 monitor.events=testkey
 
+# Start a subprocess if the PID file cannot be read. May lead to duplicate subprocesses running if this
+# is set to true
+forceStartSubProcess=false
+
 # "startPattern" is a regex defining the start of a log entry. Setting this property causes multi-line
 # log entries to be collated before being sent to ConfigService.
 # For example, if your log entries starts with a UTC timestamp (e.g., 2016-06-09T14:01:05.348) you can


### PR DESCRIPTION
In cases where the PID file cannot be read or parsed, JAU will attempt
to start the subprocess in a loop. In most observed cases, the
subprocess is not running, but the PID file is corrupt and thus no sub-
process will ever be started until the file is removed or its content
is overridden

In addition - some test cleanup/refactoring